### PR TITLE
Use hooks internally

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,17 +3,19 @@ module.exports = {
     browser: true,
     es6: true,
   },
-  extends: [
-    'eslint:recommended',
-  ],
+  extends: ['eslint:recommended', 'plugin:react/recommended'],
   parserOptions: {
     sourceType: 'module',
     ecmaVersion: 2018,
   },
+  plugins: ['react-hooks'],
   rules: {
     indent: ['error', 2],
     quotes: ['warn', 'single'],
     semi: ['warn', 'never'],
     'comma-dangle': ['warn', 'always-multiline'],
+
+    'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhaustive-deps': 'warn',
   },
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,12 @@
     "inertia": "inertiajs/inertia"
   },
   "devDependencies": {
-    "eslint": "^5.15.3"
+    "eslint": "^5.15.3",
+    "eslint-plugin-react": "^7.12.4",
+    "eslint-plugin-react-hooks": "^1.6.0",
+    "react": "^16.8.0"
+  },
+  "peerDependencies": {
+    "react": "^16.8.0"
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -15,13 +15,13 @@ class App extends Component {
   }
 
   componentDidMount() {
-    Inertia.init(this.props.initialPage, page => {
-      return Promise.resolve(this.props.resolveComponent(page.component)).then(instance => {
+    Inertia.init(this.props.initialPage, page =>
+      Promise.resolve(this.props.resolveComponent(page.component)).then(instance => {
         this.setState({
           page: { instance, props: page.props },
         })
       })
-    })
+    )
   }
 
   render() {

--- a/src/App.js
+++ b/src/App.js
@@ -1,47 +1,28 @@
 import Inertia from 'inertia'
-import { Component, createElement } from 'react'
+import { createElement, useEffect, useState } from 'react'
 import PageContext from './PageContext'
 
-class App extends Component {
-  constructor(props) {
-    super(props)
-
-    this.state = {
-      page: {
-        instance: null,
-        props: null,
-      },
-    }
-  }
-
-  componentDidMount() {
-    Inertia.init(this.props.initialPage, page =>
-      Promise.resolve(this.props.resolveComponent(page.component)).then(instance => {
-        this.setState({
-          page: { instance, props: page.props },
-        })
+export default ({ initialPage, resolveComponent }) => {
+  const [page, setPage] = useState({ instance: null, props: null })
+  useEffect(() => {
+    Inertia.init(initialPage, page =>
+      Promise.resolve(resolveComponent(page.component)).then(instance => {
+        setPage({ instance, props: page.props })
       })
     )
+  }, [])
+
+  if (!page.instance) {
+    return null
   }
 
-  render() {
-    if (!this.state.page.instance) {
-      return null
-    }
-
-    const Component = this.state.page.instance
-
-    return createElement(
-      PageContext.Provider,
-      { value: this.state.page },
-      createElement(
-        Component,
-        { key: window.location.pathname, ...this.state.page.props }
-      )
-    )
-  }
+  const Component = page.instance
+  return createElement(
+    PageContext.Provider,
+    { value: page },
+    createElement(Component, {
+      key: window.location.pathname,
+      ...page.props,
+    })
+  )
 }
-
-App.displayName = 'Inertia'
-
-export default App

--- a/src/InertiaLink.js
+++ b/src/InertiaLink.js
@@ -1,17 +1,18 @@
-import { createElement } from 'react'
 import Inertia, { shouldIntercept } from 'inertia'
+import { createElement } from 'react'
 
-export default function InertiaLink({
+export default ({
   href,
   method = 'get',
   replace = false,
   preserveScroll = false,
   children,
   ...props
-}) {
-  function visit(event) {
+}) => {
+  const visit = event => {
     if (shouldIntercept(event)) {
       event.preventDefault()
+
       Inertia.visit(href, {
         method,
         replace,

--- a/src/InertiaLink.js
+++ b/src/InertiaLink.js
@@ -1,25 +1,28 @@
 import Inertia, { shouldIntercept } from 'inertia'
-import { createElement } from 'react'
+import { createElement, useCallback } from 'react'
 
 export default ({
   href,
   method = 'get',
-  replace = false,
   preserveScroll = false,
+  replace = false,
   children,
   ...props
 }) => {
-  const visit = event => {
-    if (shouldIntercept(event)) {
-      event.preventDefault()
+  const visit = useCallback(
+    event => {
+      if (shouldIntercept(event)) {
+        event.preventDefault()
 
-      Inertia.visit(href, {
-        method,
-        replace,
-        preserveScroll,
-      })
-    }
-  }
+        Inertia.visit(href, {
+          method,
+          preserveScroll,
+          replace,
+        })
+      }
+    },
+    [href, method, preserveScroll, replace]
+  )
 
   return createElement('a', { ...props, href, onClick: visit }, children)
 }


### PR DESCRIPTION
Maybe @sebastiandedeyne can take a look at this one.

I still get the following ESLint warning:
```sh
inertia-react/src/App.js
  13:6  warning  React Hook useEffect has missing dependencies: 'initialPage' and 'resolveComponent'. Either include them or remove the dependency array. If 'resolveComponent' changes too often, find the parent component that defines it and wrap that definition in useCallback  react-hooks/exhaustive-deps
```
Since the `Inertia.init` call happened in the `componentDidMount` lifecycle, I think we can ignore this warning, no?

Closes #1 