### PR TITLE
Bring docs in sync with inertia-vue

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -243,3 +243,31 @@ function Layout({ children }) {
   )
 }
 ~~~
+
+## Remembering local component state
+
+When navigating browser history, Inertia reloads pages using prop data cached in history state. Inertia does not, however, cache local component state, since this is beyond its reach. This can lead to outdated pages in your browser history. For example, if a user partially completes a form, then navigates away, and then returns back, the form will be reset and their work will have been lost.
+
+To mitigate this issue, you can use the `useRememberedState` hook to tell Inertia.js which local component state to cache.
+
+~~~js
+import { useRememberedState } from 'inertia-react'
+
+const [formState, setFormState] = useRememberedState({
+  first_name: null,
+  last_name: null,
+  // ...
+})
+~~~
+
+If your page contains multiple components using the remember functionality, you'll need to provide a unique key for each component. For example, `Users/Create`. If you have multiple instances of the same component on the page, be sure to include a unique identifier for each of those instances. For example, `Users/Edit:{id}`.
+
+~~~js
+import { useRememberedState } from 'inertia-react'
+
+const [formState, setFormState] = useRememberedState({
+  first_name: props.user.first_name,
+  last_name: props.user.last_name,
+  // ...
+}, `Users/Edit:${props.user.id}`)
+~~~

--- a/readme.md
+++ b/readme.md
@@ -65,9 +65,9 @@ npm install @babel/plugin-syntax-dynamic-import --save
 
 Next, create a `.babelrc` file in your project with the following:
 
-~~~js
+~~~json
 {
-  plugins: ["@babel/plugin-syntax-dynamic-import"]
+  "plugins": ["@babel/plugin-syntax-dynamic-import"]
 }
 ~~~
 
@@ -75,7 +75,7 @@ Next, create a `.babelrc` file in your project with the following:
 
 Next, update your main JavaScript file to boot your Inertia app. All we're doing here is initializing React with the base Inertia page component.
 
-~~~js
+~~~jsx harmony
 import Inertia from 'inertia-react'
 import React from 'react'
 import { render } from 'react-dom'
@@ -85,7 +85,7 @@ const app = document.getElementById('app')
 render(
   <Inertia
     initialPage={JSON.parse(app.dataset.page)}
-    resolveComponent={component => import(`@/Pages/${component}`).then(module => module.default)}
+    resolveComponent={name => import(`@/Pages/${name}`).then(module => module.default)}
   />,
   app
 )
@@ -97,56 +97,63 @@ The `resolveComponent` is a callback that tells Inertia how to load a page compo
 
 While not required, for most projects it makes sense to create a default site layout that your specific pages can extend. Save this to `/Shared/Layout.js`.
 
-~~~js
+~~~jsx harmony
 import { InertiaLink } from 'inertia-react'
+import React from 'react'
 
-export default ({ children }) => (
-  <main>
-    <header>
-      <InertiaLink href="/">Home</InertiaLink>
-      <InertiaLink href="/about">About</InertiaLink>
-      <InertiaLink href="/contact">Contact</InertiaLink>
-    </header>
+function Layout({ children }) {
+  return (
+    <main>
+      <header>
+        <InertiaLink href="/">Home</InertiaLink>
+        <InertiaLink href="/about">About</InertiaLink>
+        <InertiaLink href="/contact">Contact</InertiaLink>
+      </header>
 
-    <article>{children}</article>
-  </main>
-)
+      <article>{children}</article>
+    </main>
+  )
+}
 ~~~
 
 ## Creating page components
 
 With Inertia.js, each page in your application is a JavaScript component. Here's an example of a page component. Save this to `/Pages/Welcome.js`. Note how it extends the `Layout.js` component we created above.
 
-~~~js
+~~~jsx harmony
+import React from 'react'
 import Layout from '@/Shared/Layout'
 
-export default () => (
-  <Layout>
-    <h1>Welcome</h1>
-    <p>Welcome to my first Inertia.js app!</p>
-  </Layout>
-)
+function Welcome() {
+  return (
+    <Layout>
+      <h1>Welcome</h1>
+      <p>Welcome to my first Inertia.js app!</p>
+    </Layout>
+  )
+}
 ~~~
 
 ## Creating links
 
 To create an Inertia link, use the `<InertiaLink>` component.
 
-~~~js
+~~~jsx harmony
 import { InertiaLink } from 'inertia-react'
+import React from 'react'
 
 export default () => <InertiaLink href="/">Home</InertiaLink>
 ~~~
 
 You can also specify the browser history and scroll behaviour. By default all link clicks "push" a new history state, and reset the scroll position back to the top of the page. However, you can override these defaults using the `replace` and `preserve-scroll` attributes.
 
-~~~js
+~~~jsx harmony
 <InertiaLink replace preserve-scroll href="/">Home</InertiaLink>
 ~~~
 
 You can also specify the method for the request. The default is `GET`, but you can also use `POST`, `PUT`, `PATCH`, and `DELETE`.
 
-~~~js
+~~~jsx harmony
 <InertiaLink href="/logout" method="post">Logout</InertiaLink>
 ~~~
 
@@ -185,8 +192,9 @@ Sometimes it's necessary to access the page data (props) from a non-page compone
 
 The easiest way to access page props is with our `usePageProps` hook.
 
-~~~js
+~~~jsx harmony
 import { InertiaLink, usePageProps } from 'inertia-react'
+import React from 'react'
 
 function Layout({ children }) {
   const { auth } = usePageProps()
@@ -195,15 +203,15 @@ function Layout({ children }) {
     <main>
       <header>
         You are logged in as: {auth.user.name}
+
         <nav>
           <InertiaLink href="/">Home</InertiaLink>
           <InertiaLink href="/about">About</InertiaLink>
           <InertiaLink href="/contact">Contact</InertiaLink>
         </nav>
       </header>
-      <article>
-        {children}
-      </article>
+
+      <article>{children}</article>
     </main>
   )
 }
@@ -211,9 +219,9 @@ function Layout({ children }) {
 
 If you need to access the entire Inertia `page` object, you can directly access the `PageContext` object. Note that `usePageProps` should suffice for most use cases, so we don't recommend doing this unless you have a good reason!
 
-~~~js
-import { useContext } from 'react'
+~~~jsx harmony
 import { InertiaLink, PageContext } from 'inertia-react'
+import React, { useContext } from 'react'
 
 function Layout({ children }) {
   const { props } = useContext(PageContext)
@@ -222,15 +230,15 @@ function Layout({ children }) {
     <main>
       <header>
         You are logged in as: {props.auth.user.name}
+
         <nav>
           <InertiaLink href="/">Home</InertiaLink>
           <InertiaLink href="/about">About</InertiaLink>
           <InertiaLink href="/contact">Contact</InertiaLink>
         </nav>
       </header>
-      <article>
-        {children}
-      </article>
+
+      <article>{children}</article>
     </main>
   )
 }

--- a/readme.md
+++ b/readme.md
@@ -10,32 +10,9 @@ Install using NPM:
 npm install inertiajs/inertia-react --save
 ~~~
 
-## Create root template
+## Configure server-side framework
 
-The first step to using Inertia.js is creating a root template. This template should include your assets, as well as a single `div` with a `data-page` attribute. This `div` is the root element that we'll use to boot React in, and the `data-page` attribute will the initial page information. Here's a PHP example:
-
-~~~php
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
-    <link href="{{ mix('/css/app.css') }}" rel="stylesheet">
-    <script src="{{ mix('/js/app.js') }}" defer></script>
-</head>
-<body>
-
-<div id="app" data-page="{{ json_encode($page) }}"></div>
-
-</body>
-</html>
-~~~
-
-The `$page` object should contain three values:
-
-- `component`: The name of the Vue page component.
-- `props`: The page component data (props).
-- `version`: The current asset version (if you want to use automatic asset refreshing).
+The first step when using Inertia.js is to configure your server-side framework. This primarily includes setting up a root template and updating your endpoints to return a proper Inertia response. For an example of this, see our [Laravel adapter](https://github.com/inertiajs/inertia-laravel).
 
 ## Setting up Webpack
 

--- a/readme.md
+++ b/readme.md
@@ -227,7 +227,7 @@ When navigating browser history, Inertia reloads pages using prop data cached in
 
 To mitigate this issue, you can use the `useRememberedState` hook to tell Inertia.js which local component state to cache.
 
-~~~js
+~~~jsx harmony
 import { useRememberedState } from 'inertia-react'
 
 const [formState, setFormState] = useRememberedState({
@@ -239,7 +239,7 @@ const [formState, setFormState] = useRememberedState({
 
 If your page contains multiple components using the remember functionality, you'll need to provide a unique key for each component. For example, `Users/Create`. If you have multiple instances of the same component on the page, be sure to include a unique identifier for each of those instances. For example, `Users/Edit:{id}`.
 
-~~~js
+~~~jsx harmony
 import { useRememberedState } from 'inertia-react'
 
 const [formState, setFormState] = useRememberedState({


### PR DESCRIPTION
Just like inertiajs/inertia-vue@9a38473

According to [this](https://michaelnthiessen.com/vue-props-vs-data/) article (and many others), `data` is local state:
> Data is the private memory of each component where you can store any variables you need. Props are how you pass this data from a parent component down to a child component.

With this in mind, I converted the examples from the `inertia-vue` README to using the `useState` hook.

@reinink If I'm correct the second example uses the `user` prop?  
If you want, I can make that a bit clearer here and use `props.user[key]` instead of just `user[key]` in the second example.