### PR TITLE
Don't expose PageContext, expose usePage hook instead

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -194,14 +194,14 @@ function Layout({ children }) {
 }
 ~~~
 
-If you need to access the entire Inertia `page` object, you can directly access the `PageContext` object. Note that `usePageProps` should suffice for most use cases, so we don't recommend doing this unless you have a good reason!
+If you need to access the entire Inertia `page` object, you can directly access it via the `usePage` hook. Note that `usePageProps` should suffice for most use cases, so we don't recommend doing this unless you have a good reason!
 
 ~~~jsx harmony
-import { InertiaLink, PageContext } from 'inertia-react'
-import React, { useContext } from 'react'
+import { InertiaLink, usePage } from 'inertia-react'
+import React from 'react'
 
 function Layout({ children }) {
-  const { props } = useContext(PageContext)
+  const { props } = usePage()
 
   return (
     <main>

--- a/src/PageContext.js
+++ b/src/PageContext.js
@@ -1,6 +1,3 @@
 import { createContext } from 'react'
 
-export default createContext({
-  instance: null,
-  props: {},
-})
+export default createContext()

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
 import Inertia from 'inertia'
 import App from './App'
 import InertiaLink from './Link'
-import PageContext from './PageContext'
+import usePage from './usePage'
 import usePageProps from './usePageProps'
 import useRememberedState from './useRememberedState'
 
 export default App
-export { Inertia, InertiaLink, PageContext, usePageProps, useRememberedState }
+export { Inertia, InertiaLink, usePage, usePageProps, useRememberedState }

--- a/src/usePage.js
+++ b/src/usePage.js
@@ -1,0 +1,12 @@
+import { useContext } from 'react'
+import PageContext from './PageContext'
+
+export default function usePage() {
+  const page = useContext(PageContext)
+
+  if (!page) {
+    throw new Error('usePage must be used within the Inertia component')
+  }
+
+  return page
+}

--- a/src/usePageProps.js
+++ b/src/usePageProps.js
@@ -1,8 +1,7 @@
-import { useContext } from 'react'
-import PageContext from './PageContext'
+import usePage from './usePage'
 
 export default function usePageProps() {
-  const { props } = useContext(PageContext)
+  const { props } = usePage()
 
   return props
 }


### PR DESCRIPTION
After reading @kentcdodds' [tweet](https://twitter.com/kentcdodds/status/1121440768277663745) and [article](https://kentcdodds.com/blog/application-state-management-with-react), It seemed a better idea to expose the context value as a hook instead of via the `PageContext` itself.

I also throw an error when the hook isn't  used inside the `Inertia` component (which is always the case when .

CC: @sebastiandedeyne 