### PR TITLE
Cleanup typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,12 +4,12 @@ declare namespace InertiaReact {
     PageProps extends Inertia.PageProps = {}
   > = React.FC<{
     children?: (props: {
-      Component: React.ReactNode
+      Component: React.ComponentType
       key: React.Key
       props: PageProps
     }) => React.ReactNode
     initialPage: Inertia.Page<PageProps>
-    resolveComponent: (name: string) => Promise<React.ReactNode>
+    resolveComponent: (name: string) => Promise<React.ComponentType>
     transformProps?: (props: PagePropsBeforeTransform) => PageProps
   }>
 
@@ -37,7 +37,7 @@ declare module 'inertia-react' {
   export function usePage<
     PageProps extends Inertia.PageProps = Inertia.PageProps
   >(): {
-    component: React.ReactNode | null
+    component: React.ComponentType | null
     key: number | null
     props: PageProps
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ declare namespace InertiaReact {
     PagePropsBeforeTransform extends Inertia.PagePropsBeforeTransform = {},
     PageProps extends Inertia.PageProps = {}
   > = React.FC<{
-    children?: (props: { Component: React.ReactComponentElement, key: React.Key, props: PageProps }) => React.ReactNode
+    children?: (props: { Component: React.ReactNode, key: React.Key, props: PageProps }) => React.ReactNode
     initialPage: Inertia.Page<PageProps>
     resolveComponent: (name: string) => Promise<React.ReactNode>
     transformProps?: (props: PagePropsBeforeTransform) => PageProps

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,13 +28,17 @@ declare namespace InertiaReact {
 }
 
 declare module 'inertia-react' {
-  export function usePage(): {
+  export function usePage<
+    PageProps extends Inertia.PageProps = Inertia.PageProps
+  >(): {
     component: React.ReactNode | null
     key: number | null
-    props: Inertia.PageProps
+    props: PageProps
   }
 
-  export function usePageProps(): Inertia.PageProps
+  export function usePageProps<
+    PageProps extends Inertia.PageProps = Inertia.PageProps
+  >(): PageProps
 
   export function useRememberedState<RememberedState>(
     initialState: RememberedState,

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,24 +3,30 @@ declare namespace InertiaReact {
     PagePropsBeforeTransform extends Inertia.PagePropsBeforeTransform = {},
     PageProps extends Inertia.PageProps = {}
   > = React.FC<{
-    children?: (props: { Component: React.ReactNode, key: React.Key, props: PageProps }) => React.ReactNode
+    children?: (props: {
+      Component: React.ReactNode
+      key: React.Key
+      props: PageProps
+    }) => React.ReactNode
     initialPage: Inertia.Page<PageProps>
     resolveComponent: (name: string) => Promise<React.ReactNode>
     transformProps?: (props: PagePropsBeforeTransform) => PageProps
   }>
 
   interface InertiaLinkProps {
+    className?: string
     children?: React.ReactNode
     data?: object
     href: string
     method?: string
     onClick?: (
-      event: React.MouseEvent<HTMLAnchorElement> | React.KeyboardEvent<HTMLAnchorElement>
+      event:
+        | React.MouseEvent<HTMLAnchorElement>
+        | React.KeyboardEvent<HTMLAnchorElement>
     ) => void
     preserveScroll?: boolean
     preserveState?: boolean
     replace?: boolean
-    className?: string
     style?: React.CSSProperties
   }
 


### PR DESCRIPTION
- Make `Component` prop in `children` function a `ReactNode` (see https://github.com/inertiajs/inertia-react/pull/29#discussion_r285249100)
- Make it possible to pass types to hooks instead of only via interface augmentation (see https://github.com/inertiajs/inertia-react/pull/29#discussion_r285258164)
- Formatting