### PR TITLE
Replace usePageProps with usePage

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -38,14 +38,6 @@ declare namespace InertiaReact {
 declare module 'inertia-react' {
   export function usePage<
     PageProps extends Inertia.PageProps = Inertia.PageProps
-  >(): {
-    component: React.ComponentType | null
-    key: number | null
-    props: PageProps
-  }
-
-  export function usePageProps<
-    PageProps extends Inertia.PageProps = Inertia.PageProps
   >(): PageProps
 
   export function useRememberedState<RememberedState>(

--- a/readme.md
+++ b/readme.md
@@ -240,46 +240,19 @@ Just like with an `<InertiaLink>`, you can control the history control behaviour
 
 Sometimes it's necessary to access the page data (props) from a non-page component. One really common use-case for this is the site layout. For example, maybe you want to show the currently authenticated user in your site header. This is possible using React's context feature. The base Inertia component automatically provides the current page via context, which can then be accessed by a consumer later on.
 
-The easiest way to access page props is with our `usePageProps` hook.
-
-~~~jsx harmony
-import { InertiaLink, usePageProps } from 'inertia-react'
-import React from 'react'
-
-export default function Layout({ children }) {
-  const { auth } = usePageProps()
-
-  return (
-    <main>
-      <header>
-        You are logged in as: {auth.user.name}
-
-        <nav>
-          <InertiaLink href="/">Home</InertiaLink>
-          <InertiaLink href="/about">About</InertiaLink>
-          <InertiaLink href="/contact">Contact</InertiaLink>
-        </nav>
-      </header>
-
-      <article>{children}</article>
-    </main>
-  )
-}
-~~~
-
-If you need to access the entire Inertia `page` object, you can directly access it via the `usePage` hook. Note that `usePageProps` should suffice for most use cases, so we don't recommend doing this unless you have a good reason!
+The easiest way to access page props is with our `usePage` hook.
 
 ~~~jsx harmony
 import { InertiaLink, usePage } from 'inertia-react'
 import React from 'react'
 
 export default function Layout({ children }) {
-  const { props } = usePage()
+  const { auth } = usePage()
 
   return (
     <main>
       <header>
-        You are logged in as: {props.auth.user.name}
+        You are logged in as: {auth.user.name}
 
         <nav>
           <InertiaLink href="/">Home</InertiaLink>

--- a/src/App.js
+++ b/src/App.js
@@ -31,7 +31,7 @@ export default function App({
   }, [initialPage, resolveComponent, transformProps])
 
   if (!page.component) {
-    return createElement(PageContext.Provider, { value: page }, null)
+    return createElement(PageContext.Provider, { value: page.props }, null)
   }
 
   const renderChildren = children
@@ -39,7 +39,7 @@ export default function App({
 
   return createElement(
     PageContext.Provider,
-    { value: page },
+    { value: page.props },
     renderChildren({ Component: page.component, key: page.key, props: page.props })
   )
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,7 @@ import Inertia from 'inertia'
 import App from './App'
 import InertiaLink from './Link'
 import usePage from './usePage'
-import usePageProps from './usePageProps'
 import useRememberedState from './useRememberedState'
 
 export default App
-export { Inertia, InertiaLink, usePage, usePageProps, useRememberedState }
+export { Inertia, InertiaLink, usePage, useRememberedState }

--- a/src/usePageProps.js
+++ b/src/usePageProps.js
@@ -1,7 +1,0 @@
-import usePage from './usePage'
-
-export default function usePageProps() {
-  const { props } = usePage()
-
-  return props
-}


### PR DESCRIPTION
This PR removes `usePageProps` and changes the `usePage` hook to behave like the old `usePageProps`.

This brings the package's behaviour in sync with `inertia-vue` and `inertia-svelt`. (see inertiajs/inertia-svelte#1)

There's no need to expose anything else than page props, so this hook should suffice for now. If necessary, we could add more hooks like `useVersion` in the future.

Going to test these changes in a real project tomorrow, then this should be ready to merge.