### PR TITLE
Add support for persistent layouts

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -34,8 +34,15 @@ export default function App({
     return createElement(PageContext.Provider, { value: page.props }, null)
   }
 
-  const renderChildren = children
-    || (({ Component, props, key }) => createElement(Component, { key, ...props }))
+  const renderChildren = children || (({ Component, props, key }) => {
+    const child = createElement(Component, { key, ...props })
+
+    if (Component.layout) {
+      return Component.layout(child)
+    }
+
+    return child
+  })
 
   return createElement(
     PageContext.Provider,


### PR DESCRIPTION
This adds support for persistent layouts in a very similar way to the Vue.js adapter. This also supports nested layouts.

Here's how you use this feature:

```jsx
import React from 'react'
import Layout from '../Shared/Layout'

const Home = () => {
  return (
    <React.Fragment>
      <h1 className="font-bold text-2xl">Home</h1>
      <p className="mt-4">Hello, welcome to your first Inertia app!</p>
    </React.Fragment>
  )
}

Home.layout = (child) => <Layout children={child} title="Home" />

export default Home
```

This approach is exactly how Next.js does it. However, an alternative approach would be to use a `withLayout()` function:

```jsx
import React from 'react'
import Layout from '../Shared/Layout'
import { withLayout } from 'inertia-react'

export default withLayout(() => {
  return (
    <React.Fragment>
      <h1 className="font-bold text-2xl">Home</h1>
      <p className="mt-4">Hello, welcome to your first Inertia app!</p>
    </React.Fragment>
  )
}, (child) => {
    return <Layout children={child} title="Home" />
})
```

I think I prefer the approach implemented in this PR.