### PR TITLE
Support only props in InertiaLink

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -29,6 +29,7 @@ interface InertiaLinkProps extends React.HTMLAttributes<HTMLAnchorElement> {
   preserveScroll?: boolean | ((props: Inertia.PageProps) => boolean)
   preserveState?: boolean | ((props: Inertia.PageProps) => boolean)
   replace?: boolean
+  only?: string[]
 }
 
 type InertiaLink = React.FunctionComponent<InertiaLinkProps>

--- a/src/Link.js
+++ b/src/Link.js
@@ -12,6 +12,7 @@ export default function InertiaLink({
   preserveScroll = false,
   preserveState = false,
   replace = false,
+  only = [],
   ...props
 }) {
   const visit = useCallback(event => {
@@ -26,9 +27,10 @@ export default function InertiaLink({
         preserveScroll,
         preserveState,
         replace,
+        only,
       })
     }
-  }, [data, href, method, onClick, preserveScroll, preserveState, replace])
+  }, [data, href, method, onClick, preserveScroll, preserveState, replace, only])
 
   return createElement('a', { ...props, href, onClick: visit }, children)
 }


### PR DESCRIPTION
Refers to this [document](https://inertiajs.com/requests).

We have an ability to request for specific props but this ability is missing from `InertiaLink`.

Adding support for `only` props to this components make it more simple for users to make a call.
Moreover, it is make more sense to make "manual request" and "component request" have the same ability. 

In conclusion, this PR give `InertiaLink` an ability to do the following state.

```
Inertia.visit(url, {
  method: 'post',
  data: { aKey: 'value'},
  replace: true,
  preserveState: true,
  preserveScroll: true,
  only: ['xProps'],
}) 
```

InertiaLink usage
```
 <InertiaLink
     href="/news"
     data={{ aKey: 'value'}}
     method="post"
     preserveState
     preserveScroll
     replace
 >
    some text
</InertiaLink>
```

If this PR is approved.
I will made a PR for `vue`,`svelte` and documents.
