### PR TITLE
Update InertiaLink to support references

### DIFF
--- a/src/Link.js
+++ b/src/Link.js
@@ -1,9 +1,9 @@
 import { Inertia, shouldIntercept } from '@inertiajs/inertia'
-import { createElement, useCallback } from 'react'
+import { createElement, useCallback, forwardRef } from 'react'
 
 const noop = () => undefined
 
-export default function InertiaLink({
+export default forwardRef(function InertiaLink({
   children,
   data = {},
   href,
@@ -14,7 +14,7 @@ export default function InertiaLink({
   replace = false,
   only = [],
   ...props
-}) {
+}, ref) {
   const visit = useCallback(event => {
     onClick(event)
 
@@ -32,5 +32,5 @@ export default function InertiaLink({
     }
   }, [data, href, method, onClick, preserveScroll, preserveState, replace, only])
 
-  return createElement('a', { ...props, href, onClick: visit }, children)
-}
+  return createElement('a', { ...props, href, ref, onClick: visit }, children)
+})


### PR DESCRIPTION
Presently there is no way to get a reference to the underlying element created by InertiaLink.

While references are generally discouraged, they are at times necessary for example [tooltips via Tippy.js](https://github.com/atomiks/tippyjs-react#component-children) or using an InertiaLink as an item in a [dropdown menu via reach-ui](https://reach.tech/menu-button/#menulink-as).